### PR TITLE
update link "Community Network Manual by APC" to include what APC means

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A curated list of community networks, mesh technologies, and grassroots connecti
 
 ## Governance & Policy
 - [Community Networks as a public policy](https://altermundi.net/wp-content/uploads/2023/04/NodoTAU_AlterMundi_-2-A-public-policy-in-motion.pdf)
-- [Community Network Manual by APC](https://www.apc.org/en/pubs/community-networks-manual)
+- [Community Network Manual by APC (Association for Progressive Communications)](https://www.apc.org/en/pubs/community-networks-manual)
 - [IGF Dynamic Coalition on Community Connectivity](https://comconnectivity.org/)
 
 ---


### PR DESCRIPTION
"by APC" is an abbreviation for "Association for Progressive Communications". Adding this information helps avoid confusion. [APC](https://www.apc.com) is a widely known (to computer and network folks) company that provides (among other things) battery backup and rackmount cabinets for datacenters. As this list will be of interest to network engineers (even aspiring hobby ones), at least in the US, APC will be misunderstood.